### PR TITLE
Fix missing fclose on file in ParseType01

### DIFF
--- a/PatchReader6/read.c
+++ b/PatchReader6/read.c
@@ -740,6 +740,7 @@ unsigned char* ParseType01(unsigned char* zlibBlock, char* fileName, char* outpu
 	printf("  File complete.\n");
 
 	free(buffer);
+	fclose(OldFile.fileptr);
 	free(OldFile.data);
 	free(Repeat.data);
 	fclose(writeFile);


### PR DESCRIPTION
Simple issue & fix which prevented backup & autoapply from working when using this patching method.